### PR TITLE
Add a man page and mention AUR repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+rhack.1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+PREFIX?=/usr/local
+BINDIR?=$(PREFIX)/bin
+MANDIR?=$(PREFIX)/share/man
+
+all: rhack rhack.1
+
+rhack:
+	cargo build --release
+
+test:
+	cargo test
+
+rhack.1: rhack.1.scd
+	scdoc < $< > $@
+
+clean:
+	cargo clean
+	rm -f rhack.1
+
+install: all
+	mkdir -p $(DESTDIR)/$(BINDIR) $(DESTDIR)/$(MANDIR) $(DESTDIR)/$(MANDIR)/man1
+	install -m755 target/release/rhack $(DESTDIR)/$(BINDIR)/rhack
+	install -m644 rhack.1 $(DESTDIR)/$(MANDIR)/man1/rhack.1
+
+.PHONY: all clean install

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ wget https://github.com/nakabonne/rhack/releases/download/v0.1.0/rhack_linux_amd
 apt install ./rhack_linux_amd64.deb
 ```
 
+### Arch Linux
+An [AUR package](https://aur.archlinux.org/packages/rhack/) is available.
+
+```
+» yay rhack
+  aur/rhack 0.1.0-1 (+0 0.00)
+    rhack - easily hack on your Rust dependencies
+```
+
 ### Cargo
 
 ```

--- a/README.md
+++ b/README.md
@@ -60,8 +60,20 @@ An [AUR package](https://aur.archlinux.org/packages/rhack/) is available.
     rhack - easily hack on your Rust dependencies
 ```
 
-### Cargo
+### Other Linux
+You will need `scdoc` installed in order to generate the manpage.
+```
+make all
+sudo make install
+```
 
+You can pass `PREFIX` or `DESTDIR` to control the installation destination:
+```
+sudo make PREFIX=$HOME/.local/ install
+```
+
+### Cargo
+If you just want a local install, and you don't need the manpage, you can install to `$HOME/.cargo` by running:
 ```
 cargo install rhack
 ```

--- a/rhack.1.scd
+++ b/rhack.1.scd
@@ -1,0 +1,47 @@
+rhack(1)
+
+# NAME
+
+rhack - easily edit external crates that your Rust project depends on.
+
+# SYNOPSIS
+
+*rhack* <package name>
+
+# EDITING
+
+To check out a local copy of your dependency run:
+
+	*rhack* <package name>
+
+This will make a copy of the crate in your _RHACK_DIR_, and patch your
+*Cargo.toml*.
+
+For example running *rhack reqwest* might result in a local copy
+at _~/.rhack/reqwest-0.11.1_, and an amendment to your *Cargo.toml* like this:
+
+	\[patch.crates-io\]++
+reqwest = { path = "/home/you/.rhack/reqwest-0.11.1" }
+
+# UNDO
+
+To remove changes made by *rhack* to *Cargo.toml*, run:
+
+	*rhack undo*
+
+This will _not_ remove any copies of crates in your _RHACK_DIR_.
+
+# CONFIGURATION
+
+rhack stores copies of crates in the directory specified by the _RHACK_DIR_
+environment variable.
+
+Where this is unset, the default is _$HOME/.rhack_
+
+# AUTHORS
+
+Ryo Nakao <ryo@nakao.dev>
+
+# PROJECT HOMEPAGE
+
+Sources can be found, and bugs or patches submitted at https://github.com/nakabonne/rhack


### PR DESCRIPTION
I love the tool so I added some more docs and packaged it for Arch users at https://aur.archlinux.org/packages/rhack/

![rhack-man](https://user-images.githubusercontent.com/3495954/112833270-6a69b380-908e-11eb-9da4-815ea4f3a918.png)

The file `rhack.1.scd` is in `scdoc` format, which is a more human readable format for these documents than TROFF.

I also added a tiny `Makefile` so users don't have to figure out how to generate the man page themselves, and can install them together.

The normal `cargo build` workflow is of course unchanged.

This will need a small update to the release GitHub action, but I can't easily test it from this PR.