### PR TITLE
chore: enable colored help screen

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -27,6 +27,7 @@ pub trait Cmd {
 #[clap(
     about,
     author,
+    global_setting(AppSettings::ColoredHelp)
     global_setting(AppSettings::GlobalVersion),
     global_setting(AppSettings::VersionlessSubcommands),
     version = "0.1.0"

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -27,7 +27,7 @@ pub trait Cmd {
 #[clap(
     about,
     author,
-    global_setting(AppSettings::ColoredHelp)
+    global_setting(AppSettings::ColoredHelp),
     global_setting(AppSettings::GlobalVersion),
     global_setting(AppSettings::VersionlessSubcommands),
     version = "0.1.0"


### PR DESCRIPTION
Probably personal preference, but I find it easier if commands have 
colored help as it is easier to distinguish the different sections of 
the help screen.
People who do not want colors in CLIs almost always have NO_COLOR
set anyway, so this won't affect those people, as clap follows the no
color specification: https://no-color.org/