### PR TITLE
feat: use the workspace manifest root

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -65,7 +65,11 @@ pub fn rhack_dir() -> PathBuf {
 pub fn manifest_path() -> Result<String> {
     // Run "cargo locate-project" to find out Cargo.toml file's location.
     // See: https://doc.rust-lang.org/cargo/commands/cargo-locate-project.html
-    let out = Command::new("cargo").arg("locate-project").output();
+    let out = Command::new("cargo")
+        .arg("locate-project")
+        .arg("--workspace")
+        .output();
+
     let out = match out {
         Ok(o) => o,
         Err(err) => return Err(anyhow!("failed to run \"cargo locate-project\": {:#}", err)),


### PR DESCRIPTION
When using `cargo locate-project`, specify the `--workspace` option.  This will provide a different result when within a workspace, providing the path to the top-level `Cargo.toml` file instead of the one for the workspace member. Patch changes to workspace member TOML files will not alter builds and will display a warning instead.

For projects that do not use workspaces, the output of this command is identical to the previous version.
